### PR TITLE
Add wakeup source for deep sleep

### DIFF
--- a/config/boards/shields/4c/4c.dtsi
+++ b/config/boards/shields/4c/4c.dtsi
@@ -30,6 +30,7 @@ kscan0: kscan {
             , <&pro_micro 3 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row E from the schematic file
             ;
 
+	wakeup-source;
     };
 };
 


### PR DESCRIPTION
For reference: [Low Power States - Wakeup Sources](https://zmk.dev/docs/features/low-power-states#wakeup-sources)

## Overview
Small PR to fix issue where reset button has to be pressed to wake keyboard up once it enters deep sleep. 

As deep sleep has now been enabled alongside the upgrade to Zephyr 3.5, I've found this change necessary to ensure that it is still ergonomic to use the keyboard as a daily driver (as it is a pain to have to fingernail the reset button every time I step away for too long haha)

## Previous Behaviour
Reset button on the side of the PCB had to be pressed to wake keyboard up once it entered deep sleep

## New Behaviour
Any keypress will wake the keyboard from deep sleep